### PR TITLE
Add Readme and QD for rosidl_default_runtime

### DIFF
--- a/rosidl_default_runtime/QUALITY_DECLARATION.md
+++ b/rosidl_default_runtime/QUALITY_DECLARATION.md
@@ -34,7 +34,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### Change Requests [2.i]
 
-This package requires that all changes occur through a pull request.
+All changes will occur through a pull request, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
 ### Contributor Origin [2.ii]
 

--- a/rosidl_default_runtime/QUALITY_DECLARATION.md
+++ b/rosidl_default_runtime/QUALITY_DECLARATION.md
@@ -1,0 +1,109 @@
+This document is a declaration of software quality for the `rosidl_default_runtime` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rosidl_default_runtime` Quality Declaration
+
+The package `rosidl_default_runtime` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rosidl_default_runtime` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rosidl_default_runtime` is not yet at a stable version, i.e. `>= 1.0.0`.
+
+### Public API Declaration [1.iii]
+
+`rosidl_default_runtime` does not provide any public API of its own.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rosidl_default_runtime` does not provide its own API and therefore API stability will not be impacted by changes.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rosidl_default_runtime` does not contain any c or c++ code, therefore changes will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rosidl_default_runtime` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+This package requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+Following the recommended guidelines for ROS Core packages, all pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rosidl_default_runtime` does not currently have its own features.
+
+### Public API Documentation [3.ii]
+
+`rosidl_default_runtime` does not have a public API and therefore does not require API documentation.
+
+### License [3.iii]
+
+The license for `rosidl_default_runtime` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the [LICENSE](../LICENSE) file.
+
+There are no source files in this package and therefore linters do not check for a license statement.
+
+### Copyright Statements [3.iv]
+
+There are no source code files in this package and therefore no files are currently yet copyrighted.
+
+## Testing [4]
+
+`rosidl_default_runtime` is a package providing solely CMake files and therefore does not require tests and has no coverage or performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmw` uses and passes all the standard linters and static analysis tools for a CMake package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+Results of linter tests can be found [here](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rosidl_default_runtime/).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]/[5.ii]
+
+`rosidl_default_runtime` has the following group dependencies:
+* `rosidl_runtime_packages`
+* `rosidl_typesupport_c_packages`
+* `rosidl_typesupport_cpp_packages`
+
+### Direct Runtime Non-ROS Dependencies [5.iii]
+`rosidl_default_runtime` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`rosidl_default_runtime` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+Currently nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rosidl_default_runtime/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rosidl_default_runtime/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/rosidl_default_runtime/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/rosidl_default_runtime/)
+
+## Vulnerability Disclosure Policy [7.i]
+
+This package does not yet have a Vulnerability Disclosure Policy

--- a/rosidl_default_runtime/QUALITY_DECLARATION.md
+++ b/rosidl_default_runtime/QUALITY_DECLARATION.md
@@ -26,7 +26,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
 
-`rosidl_default_runtime` does not contain any c or c++ code, therefore changes will not affect ABI stability.
+`rosidl_default_runtime` does not contain any C or C++ code, therefore changes will not affect ABI stability.
 
 ## Change Control Process [2]
 

--- a/rosidl_default_runtime/README.md
+++ b/rosidl_default_runtime/README.md
@@ -1,0 +1,7 @@
+# rosidl_default_runtime
+
+`rosidl_default_runtime` provides CMake functionality for finding and adding runtime dependencies for rosidl packages.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <!-- This is needed for the import_type_support function used by each meassage -->
+  <!-- This is needed for the import_type_support function used by each message -->
   <build_export_depend>rosidl_runtime_c</build_export_depend>
   <build_export_depend>rosidl_runtime_cpp</build_export_depend>
   <build_export_depend>rosidl_generator_py</build_export_depend>


### PR DESCRIPTION
This provides a current level quality declaration only for the rosidl_default_runtime package as `rosidl_default_generators` is not currently on the list for QDs.

Signed-off-by: Stephen Brawner <brawner@gmail.com>