### PR TITLE
[Service introspection] service_msgs dependency

### DIFF
--- a/rosidl_default_generators/package.xml
+++ b/rosidl_default_generators/package.xml
@@ -15,6 +15,7 @@
   
   <!-- Code generation for Actions depends on action_msgs -->
   <buildtool_export_depend>action_msgs</buildtool_export_depend>
+  <buildtool_export_depend>service_msgs</buildtool_export_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
 

--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -16,6 +16,7 @@
   <build_export_depend>rosidl_core_runtime</build_export_depend>
 
   <exec_depend>action_msgs</exec_depend>
+  <exec_depend>service_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Services now depend on `service_msgs`, adding to rosidl_defaults to forward the dependency to packages that generate interfaces. 

https://github.com/ros2/ros2/issues/1285


Signed-off-by: Brian Chen <brian.chen@openrobotics.org>